### PR TITLE
Update command line usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ We started Baton because we were tired of taking screenshots and manually buildi
 See [CONTRIBUTING.md](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md) for more details.
 
 # `baton-demo` Command Line Usage
+
 ```
 baton-demo
 
@@ -47,15 +48,25 @@ Usage:
   baton-demo [command]
 
 Available Commands:
+  capabilities       Get connector capabilities
   completion         Generate the autocompletion script for the specified shell
   help               Help about any command
 
 Flags:
-  -f, --file string         The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
-  -h, --help                help for baton-demo
-      --log-format string   The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
-      --log-level string    The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
-  -v, --version             version for baton-demo
+      --client-id string       The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
+      --client-secret string   The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --db-file string         A file to which the database will be written ($BATON_DB_FILE)
+                               example: /path/to/dbfile.db ($BATON_DB_FILE)
+  -f, --file string            The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
+  -h, --help                   help for baton-demo
+      --init-db                Whether to initialize the database ($BATON_INIT_DB)
+                               example: true ($BATON_INIT_DB)
+      --log-format string      The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
+      --log-level string       The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
+  -p, --provisioning           This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
+      --skip-full-sync         This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
+      --ticketing              This must be set to enable ticketing support ($BATON_TICKETING)
+  -v, --version                version for baton-demo
 
 Use "baton-demo [command] --help" for more information about a command.
 ```


### PR DESCRIPTION
This PR updates the command line usage section in the README to match the current --help output.