### PR TITLE
Add GORELEASER_PRO_KEY secret for MSI builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,4 @@ jobs:
       AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
       AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      GORELEASER_PRO_KEY: ${{ secrets.GORELEASER_PRO_KEY }}


### PR DESCRIPTION
Adds the `GORELEASER_PRO_KEY` secret required by the shared release workflow for building MSI Windows installers. The `msi` input defaults to `true`, so MSI installers are built automatically.

**Depends on:** [github-workflows PR #45](https://github.com/ConductorOne/github-workflows/pull/45)