### PR TITLE
[OPS-1301] Use baton-ci app token in output_capabilities.yaml

### DIFF
--- a/.github/workflows/output_capabilities.yaml
+++ b/.github/workflows/output_capabilities.yaml
@@ -10,10 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint baton-ci app token
+        id: ci-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BATON_CI_CLIENT_ID }}
+          private-key: ${{ secrets.BATON_CI_SECRET_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RELENG_GITHUB_TOKEN }}
+          token: ${{ steps.ci-token.outputs.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Why

The legacy `output_capabilities.yaml` workflow uses `RELENG_GITHUB_TOKEN` to push the auto-generated `baton_capabilities.json` back to `main`. With the Connector Rules ruleset hardened in OPS-1300, only `baton-ci[bot]` can bypass branch protection on `main`. The PAT-tied user is currently only working because of the temporary org-admin mitigation; once that mitigation is removed this workflow will silently fail at the auto-commit step.

## What

Replace the long-lived PAT with a short-lived `baton-ci` app token scoped to the current repo, mirroring the OPS-1300 templated workflow pattern.

## Test plan

- [ ] After merge, the next push to main triggers the workflow; verify it mints the token, builds, and pushes the metadata commit successfully (or stays a no-op if metadata is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)