### PR TITLE
Clean up baton-demo managed files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,39 +6,6 @@ on:
     branches:
       - main
 jobs:
-  go-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Run linters
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.4
-          args: --timeout=3m
-  go-test:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: go tests
-        run: go test -v -covermode=count -json ./... > test.json
-      - name: annotate go tests
-        if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
-        with:
-          test-results: test.json
   sync-test:
     runs-on: ubuntu-latest
     env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @laurenleach @btipling

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM gcr.io/distroless/static-debian11:nonroot
-ENTRYPOINT ["/baton-demo"]
-COPY baton-demo /


### PR DESCRIPTION
## Why

baton-demo is moving under baton-admin connector management. Once that lands, the repo-local Dockerfile, CODEOWNERS file, and standard lint/test jobs are redundant with shared connector management.

## What this changes

This removes the repo-local Dockerfile because the shared release workflow generates the default container Dockerfile unless a custom Dockerfile template is configured.

This removes CODEOWNERS because active rulesets do not require code owner review, and connector review is handled by connector rulesets.

This removes only the go-lint and go-test jobs from ci.yaml. The connector-specific sync-test job remains in place.

## Validation

- go test -mod=vendor ./...
- go build -mod=vendor ./cmd/baton-demo

## Merge Order

Depends on ConductorOne/baton-admin#728. Merge this after baton-admin has added baton-demo as a managed connector and pushed the connector-managed workflow files.