### PR TITLE
Remove stale gosec nolint directives

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -560,7 +560,7 @@ func (c *Client) ListUsers(ctx context.Context, pToken *pagination.Token) ([]*Us
 	q := c.db.From(users.Name()).Prepared(true)
 	q = q.Select("id", "name", "email", "enabled", "account_type", "attrs", "created_at", "updated_at").
 		Order(goqu.C("id").Asc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()
@@ -618,7 +618,7 @@ func (c *Client) ListUsersByUpdatedAt(ctx context.Context, updatedAt time.Time, 
 		Select("id", "name", "email", "enabled", "account_type", "attrs", "created_at", "updated_at").
 		Where(goqu.C("updated_at").Gt(updatedAt)).
 		Order(goqu.C("updated_at").Desc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()
@@ -1557,7 +1557,7 @@ func (c *Client) ListGroupsByUpdatedAt(ctx context.Context, updatedAt time.Time,
 		Select("id", "name", "admins", "members", "created_at", "updated_at").
 		Where(goqu.C("updated_at").Gt(updatedAt)).
 		Order(goqu.C("updated_at").Desc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()
@@ -1615,7 +1615,7 @@ func (c *Client) ListRolesByUpdatedAt(ctx context.Context, updatedAt time.Time, 
 		Select("id", "name", "direct_assignments", "group_assignments", "created_at", "updated_at").
 		Where(goqu.C("updated_at").Gt(updatedAt)).
 		Order(goqu.C("updated_at").Desc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()
@@ -1673,7 +1673,7 @@ func (c *Client) ListProjectsByUpdatedAt(ctx context.Context, updatedAt time.Tim
 		Select("id", "name", "owner", "group_assignments", "created_at", "updated_at").
 		Where(goqu.C("updated_at").Gt(updatedAt)).
 		Order(goqu.C("updated_at").Desc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()
@@ -1731,7 +1731,7 @@ func (c *Client) ListScopedRolesByUpdatedAt(ctx context.Context, updatedAt time.
 		Select("id", "project_id", "role_id", "user_assignments", "created_at", "updated_at").
 		Where(goqu.C("updated_at").Gt(updatedAt)).
 		Order(goqu.C("updated_at").Desc()).
-		Limit(uint(limit)). //nolint:gosec // This won't underflow
+		Limit(uint(limit)).
 		Offset(uint(offset))
 
 	query, args, err := q.ToSQL()


### PR DESCRIPTION
## Why

The managed verify workflow now fails lint on main because six `//nolint:gosec` directives are no longer suppressing an active gosec finding. `nolintlint` reports those directives as unused.

## What this changes

This removes the stale `//nolint:gosec` comments from the checked `Limit(uint(limit))` calls while leaving the existing pagination behavior unchanged.

Current main status before this fix: latest push workflows at `8ee67f43` show Connector Docs, Go Dependency Submission, ci, Generate Baton Metadata, and Output connector capabilities passing; Verify fails only in `verify / lint`. `verify / test` and `verify / docs` passed, and regression is skipped by config.

## Validation

- go test -mod=vendor ./...
- go build -mod=vendor ./cmd/baton-demo
- golangci-lint run --modules-download-mode=vendor --timeout=6m

Note: `golangci-lint run --timeout=6m` without vendor mode attempted to resolve dependencies over the network locally and failed DNS; the vendor-mode lint command passed with 0 issues.